### PR TITLE
fix: arguments order filename hashing

### DIFF
--- a/lib/ruby/reports/base_report.rb
+++ b/lib/ruby/reports/base_report.rb
@@ -120,11 +120,15 @@ module Ruby
         @error_handle_block = block
       end
 
+      private
+
       def formatter
         nil
       end
 
-      private
+      def config
+        @config ||= Config.new(self.class.config_hash)
+      end
 
       def assign_attributes
         if args && (attrs_hash = args.first) && attrs_hash.is_a?(Hash)
@@ -142,12 +146,8 @@ module Ruby
         @iterator ||= Services::DataIterator.new(query, config)
       end
 
-      def config
-        @config ||= Config.new(self.class.config_hash)
-      end
-
       def table
-        @table ||= Services::TableBuilder.new(self, self.class.table_block, config)
+        @table ||= Services::TableBuilder.new(self, self.class.table_block, config, formatter)
       end
 
       def cache_file

--- a/lib/ruby/reports/services/data_iterator.rb
+++ b/lib/ruby/reports/services/data_iterator.rb
@@ -20,7 +20,7 @@ module Ruby
 
           batch_offset = 0
 
-          while (rows = query.request_batch(batch_offset)).size > 0 do
+          while (rows = query.request_batch(batch_offset)).count > 0 do
             rows.each { |row| yield row }
             batch_offset += config.batch_size
           end
@@ -31,7 +31,7 @@ module Ruby
         # Returns Fixnum
         def data_size
           @data_size ||= if custom_source
-                           custom_source.size
+                           custom_source.count
                          else
                            query.request_count
                          end

--- a/lib/ruby/reports/services/filename_generator.rb
+++ b/lib/ruby/reports/services/filename_generator.rb
@@ -1,5 +1,4 @@
 require 'digest'
-require 'json'
 
 # coding: utf-8
 module Ruby
@@ -25,7 +24,25 @@ module Ruby
         private
 
         def self.hash(*args)
-          Digest::SHA1.hexdigest(args.to_json)
+          Digest::SHA1.hexdigest(obj_to_string(args))
+        end
+
+        def self.obj_to_string(obj)
+          case obj
+          when Hash
+            s = []
+            obj.keys.sort.each do |k|
+              s << obj_to_string(k)
+              s << obj_to_string(obj[k])
+            end
+            s.to_s
+          when Array
+            s = []
+            obj.each { |a| s << obj_to_string(a) }
+            s.to_s
+          else
+            obj.to_s
+          end
         end
       end
     end

--- a/lib/ruby/reports/services/query_builder.rb
+++ b/lib/ruby/reports/services/query_builder.rb
@@ -3,14 +3,14 @@ module Ruby
     module Services
       class QueryBuilder
         extend Forwardable
-        pattr_initialize :report
+        pattr_initialize :report, :config
 
         def request_count
           execute(count)[0]['count'].to_i
         end
 
         def request_batch(offset)
-          execute take_batch(report.config.batch_size, offset)
+          execute take_batch(config.batch_size, offset)
         end
 
         private
@@ -77,10 +77,9 @@ module Ruby
         # Internal: Порядок строк отчета
         #
         # Returns String (SQL)
-        def order
+        def order_by
           nil
         end
-        alias_method :order_by, :order
 
         # Internal: Фильтры отчета
         #
@@ -105,7 +104,7 @@ module Ruby
           query.project(Arel.sql(select))
                .take(limit)
                .skip(offset)
-               .order(order)
+               .order(order_by)
                .to_sql
         end
       end

--- a/lib/ruby/reports/services/table_builder.rb
+++ b/lib/ruby/reports/services/table_builder.rb
@@ -11,7 +11,7 @@ module Ruby
       # Defines report table building logic
       class TableBuilder
         attr_reader :building_header
-        pattr_initialize :report, :table_block, :config do
+        pattr_initialize :report, :table_block, :config, :formatter do
           init_table
         end
 
@@ -38,6 +38,8 @@ module Ruby
           @building_header = true
           header = DslProxy.exec(self, Dummy.new, &table_block)
           @building_header = false
+
+          cleanup_header
           header
         end
 
@@ -48,12 +50,16 @@ module Ruby
         end
 
         def init_table
-          @table_header = []
-          @table_row = []
+          cleanup_header
+          cleanup_row
         end
 
         def cleanup_row
           @table_row = []
+        end
+
+        def cleanup_header
+          @table_header = []
         end
 
         def add_header_cell(column_name)
@@ -64,7 +70,7 @@ module Ruby
           column_value = @row[column_value] if column_value.is_a? Symbol
 
           if (formatter_name = options[:formatter])
-            column_value = report.formatter.send(formatter_name, column_value)
+            column_value = formatter.send(formatter_name, column_value)
           end
 
           @table_row << encoded_string(column_value)

--- a/spec/ruby/reports/base_report_spec.rb
+++ b/spec/ruby/reports/base_report_spec.rb
@@ -50,12 +50,10 @@ class MyReport < MyTypeReport
   end
 
   def query
-    @query ||= Query.new(self)
+    @query ||= Query.new(self, config)
   end
 
-  class Query
-    pattr_initialize :report
-
+  class Query < Ruby::Reports::Services::QueryBuilder
     def select_data
       [{one: 'one', two: 'one'}, {one: report.main_param, two: report.main_param}]
     end

--- a/spec/ruby/reports/csv_report_spec.rb
+++ b/spec/ruby/reports/csv_report_spec.rb
@@ -34,7 +34,7 @@ class MyCsvReport < Ruby::Reports::CsvReport
   end
 
   def query
-    @query ||= Query.new(self)
+    @query ||= Query.new(self, config)
   end
 
   class Formatter
@@ -43,8 +43,7 @@ class MyCsvReport < Ruby::Reports::CsvReport
     end
   end
 
-  class Query
-    pattr_initialize :report
+  class Query < ::Ruby::Reports::Services::QueryBuilder
     def select_data
       [{:first => :one, :second => report.main_param, :third => 3}]
     end


### PR DESCRIPTION
There is a bug, guilty for identifiing MyReport.build(a: 1, b: 2) and
MyReport.build(b: 2, a: 1) as different reports

ALSO:
- Iterator used #size instead of #count
- Table Builder did not clear @table_header after building
- Query Builder used #order instead of #order_by
- Base Report #formatter and #config methods were exposed unnecessarily
