### PR TITLE
feat: building report with objects

### DIFF
--- a/lib/ruby/reports.rb
+++ b/lib/ruby/reports.rb
@@ -8,6 +8,7 @@ require 'ruby/reports/base_report'
 require 'ruby/reports/csv_report'
 require 'ruby/reports/cache_file'
 require 'ruby/reports/config'
+require 'ruby/reports/storages'
 
 require 'ruby/reports/version'
 

--- a/lib/ruby/reports/config.rb
+++ b/lib/ruby/reports/config.rb
@@ -6,7 +6,16 @@ module Ruby
       DEFAULT_CODING = 'utf-8'.freeze
       DEFAULT_CSV_OPTIONS = {col_sep: ';', row_sep: "\r\n"}
 
-      DEFAULT_CONFIG_ATTRIBUTES = [:directory, :source, :extension, :batch_size, :encoding, :expire_in, :csv_options]
+      DEFAULT_CONFIG_ATTRIBUTES = [
+        :directory,
+        :source,
+        :extension,
+        :batch_size,
+        :encoding,
+        :expire_in,
+        :csv_options,
+        :storage
+      ]
 
       def self.config_attributes
         DEFAULT_CONFIG_ATTRIBUTES
@@ -18,6 +27,7 @@ module Ruby
         @encoding ||= DEFAULT_CODING
         @expire_in ||= DEFAULT_EXPIRE_TIME
         @csv_options ||= DEFAULT_CSV_OPTIONS
+        @storage ||= Storages::OBJECT
       end
     end
   end

--- a/lib/ruby/reports/services/table_builder.rb
+++ b/lib/ruby/reports/services/table_builder.rb
@@ -67,13 +67,24 @@ module Ruby
         end
 
         def add_row_cell(column_value, options = {})
-          column_value = @row[column_value] if column_value.is_a? Symbol
+          column_value = read_from_storage(column_value) if column_value.is_a? Symbol
 
           if (formatter_name = options[:formatter])
             column_value = formatter.send(formatter_name, column_value)
           end
 
           @table_row << encoded_string(column_value)
+        end
+
+        def read_from_storage(column)
+          case config.storage
+          when :object
+            @row.public_send(column)
+          when :hash
+            @row[column]
+          else
+            fail 'Unknown Storage set in report config'
+          end
         end
 
         class Dummy

--- a/lib/ruby/reports/storages.rb
+++ b/lib/ruby/reports/storages.rb
@@ -1,0 +1,9 @@
+module Ruby
+  module Reports
+    module Storages
+      HASH = :hash
+      OBJECT = :object
+    end
+  end
+end
+

--- a/spec/ruby/reports/base_report_spec.rb
+++ b/spec/ruby/reports/base_report_spec.rb
@@ -6,6 +6,7 @@ class MyTypeReport < Ruby::Reports::BaseReport
   def initialize(*args)
     super
     config.extension = :type
+    config.storage = Ruby::Reports::Storages::HASH
   end
 
   def write(io, force = false)


### PR DESCRIPTION
CAUTION: breaking change, by default RubyReports treat query as Object
storage

This feature introduces Storages. You can specify what storage you are
using in query. For now two options available:
- Ruby::Reports::Storages::HASH, report treats each row as Hash, each
  column reads as key from it.
- Ruby::Reports::Storages::OBJECT, report treats each row as Ruby
  Object, each column reads as public method call on it.

CAUTION: breaking change, by default RubyReports treat query as Object
storage
